### PR TITLE
fix: 假绿灯、被吞的失败、指向不存在工具的描述

### DIFF
--- a/tools/tiaportal-mcp/src/TiaMcpServer/Cli/CliCommands.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/Cli/CliCommands.cs
@@ -69,10 +69,15 @@ namespace TiaMcpServer.Cli
             EnsureConnectedOpen(Positional(args));
             var plc = Opt(args, "--plc") ?? "PLC_1";
             var c = McpServer.CompileAndDiagnosePlc(plc);
-            bool clean = (c.ErrorCount ?? 0) == 0;
+            // 三态：ErrorCount==null 表示编译结果没读回来，不是零错误。
+            // 原来的 ?? 0 会让"读不回来"退 0，脚本和 CI 会当成编译干净，这里必须退 1。
+            bool? clean = c.ErrorCount == null ? (bool?)null : c.ErrorCount.Value == 0;
+            var errorsText = c.ErrorCount?.ToString() ?? "(unreadable)";
+            var warningsText = c.WarningCount?.ToString() ?? "(unreadable)";
             if (Flag(args, "--json")) Console.WriteLine(Json(c));
-            else Console.WriteLine($"compile {plc}: state={c.State} errors={c.ErrorCount} warnings={c.WarningCount}");
-            return clean ? 0 : 1;
+            else if (clean == null) Console.WriteLine($"compile {plc}: state={c.State} errors={errorsText} warnings={warningsText} (compile result unreadable, NOT verified)");
+            else Console.WriteLine($"compile {plc}: state={c.State} errors={errorsText} warnings={warningsText}");
+            return clean == true ? 0 : 1;
         }
 
         private static int Describe(string[] args)

--- a/tools/tiaportal-mcp/src/TiaMcpServer/ModelContextProtocol/HmiTemplateLayoutAnalyzer.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/ModelContextProtocol/HmiTemplateLayoutAnalyzer.cs
@@ -9,8 +9,28 @@ namespace TiaMcpServer.ModelContextProtocol
 {
     public static class HmiTemplateLayoutAnalyzer
     {
-        public static JsonObject AnalyzeDirectory(string templateDirectory, Func<string, bool>? executionJsonCheck = null)
+        /// <summary>
+        /// 真实的执行 JSON 构建检查：读模板条目数 → 用本仓的执行 JSON 构建器生成 → 比对 items 数是否一致。
+        /// 之所以要有这个默认实现，是因为过去调用方不传委托时会退化成「前面没报错就算验过」，
+        /// 而那个判据里已经含着 errors.Count == 0，永远不可能新增错误 —— 等于没检查却报 pass。
+        /// </summary>
+        public static bool ExecutionJsonBuilds(string templateFile)
         {
+            var templateRoot = JsonNode.Parse(File.ReadAllText(templateFile)) as JsonObject;
+            var expectedItems = (templateRoot?["Items"] as JsonArray ?? templateRoot?["items"] as JsonArray ?? new JsonArray()).Count;
+            var screen = templateRoot?["Screen"] as JsonObject ?? templateRoot?["screen"] as JsonObject ?? new JsonObject();
+            // 回退宽高与 Program.ReportBuilders 的 TemplateExecutionJsonBuilds 保持一致，避免同一模板两处判定不同。
+            var width = GetJsonInt(screen["Width"] ?? screen["width"], 800);
+            var height = GetJsonInt(screen["Height"] ?? screen["height"], 480);
+            var execution = HmiTemplateDesignJsonBuilder.BuildApplyDesign(templateFile, width, height);
+            return execution["items"] is JsonArray executionItems && executionItems.Count == expectedItems;
+        }
+
+        public static JsonObject AnalyzeDirectory(string templateDirectory, Func<string, bool> executionJsonCheck)
+        {
+            // 必填：不传委托就没有真检查可做，这条路必须在编译期/入口处堵死，不允许悄悄退化成恒真。
+            if (executionJsonCheck == null) throw new ArgumentNullException(nameof(executionJsonCheck));
+
             var files = Directory.Exists(templateDirectory)
                 ? Directory.GetFiles(templateDirectory, "*.json", SearchOption.TopDirectoryOnly)
                     .Where(path => Path.GetFileName(path).StartsWith("unified_", StringComparison.OrdinalIgnoreCase))
@@ -41,8 +61,10 @@ namespace TiaMcpServer.ModelContextProtocol
             };
         }
 
-        public static JsonObject AnalyzeFile(string templateFile, Func<string, bool>? executionJsonCheck = null)
+        public static JsonObject AnalyzeFile(string templateFile, Func<string, bool> executionJsonCheck)
         {
+            if (executionJsonCheck == null) throw new ArgumentNullException(nameof(executionJsonCheck));
+
             var errors = new JsonArray();
             var warnings = new JsonArray();
             var row = new JsonObject
@@ -185,9 +207,7 @@ namespace TiaMcpServer.ModelContextProtocol
 
             try
             {
-                row["executionJsonChecked"] = executionJsonCheck == null
-                    ? items.Length > 0 && errors.Count == 0
-                    : executionJsonCheck(templateFile);
+                row["executionJsonChecked"] = executionJsonCheck(templateFile);
                 if (!string.Equals(row["executionJsonChecked"]?.ToString(), "True", StringComparison.OrdinalIgnoreCase))
                 {
                     errors.Add("execution-json-build-failed: generated execution JSON item count mismatch.");

--- a/tools/tiaportal-mcp/src/TiaMcpServer/ModelContextProtocol/McpServer.Documents.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/ModelContextProtocol/McpServer.Documents.cs
@@ -579,7 +579,7 @@ namespace TiaMcpServer.ModelContextProtocol
         [McpServerTool(Name = "GetObjectProperty"), Description("[L2][Reflection]Get an Openness object property by dotted path. Use after DescribeObject/DescribeObjectProperty to safely inspect current state before writing.")]
         public static ResponseObjectValue GetObjectProperty(
             [Description("Object kind: Project|Portal|Device|DeviceItem|Software|Block|Type|HmiScreen|HmiTag|HmiScreenItem")] string objectKind,
-            [Description("Object path")] string objectPath,
+            [Description("Object path. For Device/DeviceItem/Software: path in project tree. For Block/Type: blockPath/typePath.")] string objectPath,
             [Description("Property path, e.g. Name or BlockGroup.Groups")] string propertyPath,
             [Description("softwarePath required for Block/Type")] string softwarePath = "")
         {
@@ -596,7 +596,7 @@ namespace TiaMcpServer.ModelContextProtocol
         [McpServerTool(Name = "ListObjectChildren"), Description("[L2][Reflection]List child items from an enumerable Openness property, e.g. Devices, DeviceItems, Connections, Screens, Blocks. Use to discover paths instead of guessing.")]
         public static ResponseObjectChildren ListObjectChildren(
             [Description("Object kind: Project|Portal|Device|DeviceItem|Software|Block|Type|HmiScreen|HmiTag|HmiScreenItem")] string objectKind,
-            [Description("Object path")] string objectPath,
+            [Description("Object path. For Device/DeviceItem/Software: path in project tree. For Block/Type: blockPath/typePath.")] string objectPath,
             [Description("Enumerable property name/path, e.g. Devices, DeviceItems, BlockGroup.Blocks")] string collectionProperty,
             [Description("softwarePath required for Block/Type")] string softwarePath = "",
             [Description("Max child items to return")] int limit = 200)
@@ -614,7 +614,7 @@ namespace TiaMcpServer.ModelContextProtocol
         [McpServerTool(Name = "InvokeObject"), Description("[L2][Reflection]Invoke an Openness method via reflection. Default is read-oriented; set allowWrite=true only after DescribeObject confirms the target method/signature. This is the generic bridge for public API operations not yet wrapped by MCP.")]
         public static ResponseObjectValue InvokeObject(
             [Description("Object kind: Project|Portal|Device|DeviceItem|Software|Block|Type|HmiScreen|HmiTag|HmiScreenItem")] string objectKind,
-            [Description("Object path")] string objectPath,
+            [Description("Object path. For Device/DeviceItem/Software: path in project tree. For Block/Type: blockPath/typePath.")] string objectPath,
             [Description("Method name (case-insensitive)")] string methodName,
             [Description("JSON array of args, e.g. [\"AttrName\"]. Empty for no args.")] System.Text.Json.JsonElement[]? args = null,
             [Description("softwarePath required for Block/Type")] string softwarePath = "",
@@ -637,7 +637,7 @@ namespace TiaMcpServer.ModelContextProtocol
         [McpServerTool(Name = "DescribeService"), Description("[L2][Reflection]GetService bridge: describe a service object (by type name suffix) from a target object.")]
         public static ResponseObjectDescribe DescribeService(
             [Description("Target object kind: Project|Portal|Device|DeviceItem|Software|Block|Type")] string objectKind,
-            [Description("Target object path")] string objectPath,
+            [Description("Target object path. For Device/DeviceItem/Software: path in project tree. For Block/Type: blockPath/typePath.")] string objectPath,
             [Description("Service type suffix, e.g. CrossReferenceService or ICompilable")] string serviceTypeSuffix,
             [Description("softwarePath required for Block/Type")] string softwarePath = "",
             [Description("Max member count to return")] int maxMembers = 200)
@@ -655,7 +655,7 @@ namespace TiaMcpServer.ModelContextProtocol
         [McpServerTool(Name = "InvokeService"), Description("[L2][Reflection]GetService bridge: invoke a method on a service object (by type name suffix) from a target object.")]
         public static ResponseObjectValue InvokeService(
             [Description("Target object kind: Project|Portal|Device|DeviceItem|Software|Block|Type")] string objectKind,
-            [Description("Target object path")] string objectPath,
+            [Description("Target object path. For Device/DeviceItem/Software: path in project tree. For Block/Type: blockPath/typePath.")] string objectPath,
             [Description("Service type suffix, e.g. CrossReferenceService or ICompilable")] string serviceTypeSuffix,
             [Description("Method name (case-insensitive)")] string methodName,
             [Description("JSON array of args, empty for no args")] System.Text.Json.JsonElement[]? args = null,

--- a/tools/tiaportal-mcp/src/TiaMcpServer/ModelContextProtocol/McpServer.PlcSoftware.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/ModelContextProtocol/McpServer.PlcSoftware.cs
@@ -2366,7 +2366,10 @@ namespace TiaMcpServer.ModelContextProtocol
             "[L2][Category:PLC-Online][PreCondition:Connect+OpenProject]" +
             " List all force table names in the PLC software." +
             " Force tables configure which variables are continuously forced to specific values while the CPU is online." +
-            " Use SetForceTableEntry to configure entries, then go online for the forces to take effect.")]
+            " Read-only: this server exposes NO tool for creating or editing force entries — forcing overrides live PLC logic" +
+            " (a forced output stays forced regardless of what the program writes) and is deliberately kept out of the AI tool surface." +
+            " Create or edit force entries in the TIA Portal UI. For a one-shot value written from a watch table instead," +
+            " use SetWatchTableModifyValue (the variable reverts to PLC logic afterwards).")]
         public static ResponseStringList GetPlcForceTables(
             [Description("softwarePath: path to the PLC software, e.g. 'PLC_1'")] string softwarePath)
         {
@@ -2392,7 +2395,14 @@ namespace TiaMcpServer.ModelContextProtocol
             " This is an OFFLINE CONFIGURATION step — the value is written to the PLC only when TIA Portal is online and the trigger fires." +
             " Trigger options: Permanent (every cycle), PermanentAtStart (every cycle, at scan start), OnceOnlyAtStart (single write at scan start), PermanentAtEnd, OnceOnlyAtEnd, OnceOnlyAtStop." +
             " Use GoOnline before calling this for the write to reach the PLC." +
-            " Does NOT use Force — variable reverts to PLC logic after the modify. To hold a value persistently, use SetForceTableEntry instead." +
+            " SAFETY: the target is a variable in the physical CPU, not a simulation. The moment the trigger fires the value" +
+            " lands on the real address — if that address is a coil, a valve, a contactor or a drive enable, the machine moves" +
+            " at that instant, with no acknowledgement step. Before calling, know exactly what the address drives and confirm" +
+            " nobody is at or inside the machine. The resulting physical motion is NOT undone by calling this tool again with" +
+            " another value; the equipment stays wherever it moved to." +
+            " Not a Force: this writes the value once per trigger event and the variable then follows PLC logic again" +
+            " (a force would keep overriding the program continuously). This server exposes no tool for force entries —" +
+            " GetPlcForceTables only lists them; use TIA Portal directly to force a value." +
             " Example: SetWatchTableModifyValue('PLC_1', 'Debug_WT', 'DB1.DBX0.0', 'TRUE', 'OnceOnlyAtStart')")]
         public static ResponseMessage SetWatchTableModifyValue(
             [Description("softwarePath: path to the PLC software, e.g. 'PLC_1'")] string softwarePath,
@@ -2988,7 +2998,9 @@ namespace TiaMcpServer.ModelContextProtocol
         {
             try
             {
-                var data = HmiTemplateLayoutAnalyzer.AnalyzeDirectory(templateDirectory);
+                // 必须显式传检查委托：不传时 "execution JSON shape" 这项检查会退化成恒真的同义反复，
+                // 工具描述里承诺的检查等于空转，模板报错也照样返回 ok。
+                var data = HmiTemplateLayoutAnalyzer.AnalyzeDirectory(templateDirectory, HmiTemplateLayoutAnalyzer.ExecutionJsonBuilds);
                 var ok = data["ok"]?.GetValue<bool>() == true;
                 return new ResponseJsonReport
                 {
@@ -3013,7 +3025,8 @@ namespace TiaMcpServer.ModelContextProtocol
             "[L2][Category:PLC-TechnologyObjects][PreCondition:Connect+OpenProject]" +
             " List all Technology Objects (TOs) in the PLC software: axes, cams, measuring inputs, etc." +
             " Returns each TO's Name, type (OfSystemLibElement), and firmware version (OfSystemLibVersion)." +
-            " Use this to discover TO names before ExportTechnologyObject or GetAxisParameters." +
+            " Use this to discover TO names before ExportTechnologyObject." +
+            " No tool returns axis/TO parameter values directly — export the TO with ExportTechnologyObject and read the XML file." +
             " TOs are stored as TechnologicalInstanceDB instances in the TechnologicalObjectGroup.")]
         public static ResponseTechnologyObjectList GetTechnologyObjects(
             [Description("softwarePath: path to the PLC software, e.g. 'PLC_1'")] string softwarePath)
@@ -3745,7 +3758,7 @@ namespace TiaMcpServer.ModelContextProtocol
             " Download the compiled PLC program to the physical CPU over the network." +
             " The CPU will stop briefly during download and restart automatically (controlled by startAfterDownload)." +
             " SAFETY: Verify no personnel are near the machine before downloading. This changes live PLC behavior." +
-            " Workflow: Connect → OpenProject → CompileSoftware → CheckDownloadReadiness → DownloadToPlc → GetCpuOnlineState." +
+            " Workflow: Connect → OpenProject → CompileSoftware → CheckDownloadReadiness → DownloadToPlc → GetOnlineState." +
             " On success State=Success or Warning. On Error check Errors[] for details." +
             " Default options (keepActualValues=true, consistentBlocksOnly=true) are safe for most scenarios." +
             " Set keepActualValues=false only when DB initial values must be reset — this is irreversible." +

--- a/tools/tiaportal-mcp/src/TiaMcpServer/ModelContextProtocol/OfflineReleaseValidationSuite.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/ModelContextProtocol/OfflineReleaseValidationSuite.cs
@@ -35,7 +35,8 @@ namespace TiaMcpServer.ModelContextProtocol
             var classicSuite = ClassicHmiOfflineValidationSuite.Run(Path.Combine(suiteDir, "classic_hmi"));
             var classicImportPreflight = ClassicHmiTemporaryImportPreflightSuite.Run(workspaceRoot, Path.Combine(suiteDir, "classic_hmi_temporary_import_preflight"));
             var plcSymbolProbe = PlcSymbolManifestBuilder.RunProbe(Path.Combine(suiteDir, "plc_symbol_manifest"));
-            var hmiLayout = HmiTemplateLayoutAnalyzer.AnalyzeDirectory(hmiTemplateDir);
+            // 发布闸必须跑真的执行 JSON 构建检查：以前这里不传委托，等于把「没报错」当成「验过了」，对外发版从没验过这条路径。
+            var hmiLayout = HmiTemplateLayoutAnalyzer.AnalyzeDirectory(hmiTemplateDir, HmiTemplateLayoutAnalyzer.ExecutionJsonBuilds);
             WriteJsonAndMarkdown(
                 hmiLayout,
                 Path.Combine(suiteDir, "hmi_template_layout", "hmi_template_layout_release_" + stamp + ".json"),

--- a/tools/tiaportal-mcp/src/TiaMcpServer/Program.CliProbes.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/Program.CliProbes.cs
@@ -22,6 +22,10 @@ namespace TiaMcpServer
     // Partial: cli probe/test commands. Extracted from Program.cs (god-file split); behavior unchanged.
     public partial class Program
     {
+        // ErrorCount/WarningCount 是 int?，null 专门表示「编译结果没读回来」，不是 0。
+        // 直接插进文本会打出 errors= 后面一片空白，看着像零错误，所以统一显示成 (unreadable)。
+        private static string CountText(int? count) => count?.ToString() ?? "(unreadable)";
+
         private static void RunOnlineMonitoringSafetySelfTest()
         {
             var result = McpServer.RunOnlineMonitoringSafetySelfTest();
@@ -77,7 +81,7 @@ namespace TiaMcpServer
                     LogDiag($"PLC import failure: {failure.Path} :: {failure.Error}");
             }
             if (import.Compile != null)
-                LogDiag($"PLC compile: {import.Compile.State}, errors={import.Compile.ErrorCount}, warnings={import.Compile.WarningCount}");
+                LogDiag($"PLC compile: {import.Compile.State}, errors={CountText(import.Compile.ErrorCount)}, warnings={CountText(import.Compile.WarningCount)}");
 
             if (hmi.Ok == true)
             {
@@ -134,7 +138,7 @@ namespace TiaMcpServer
             }
             if (import.Compile != null)
             {
-                LogDiag($"PLC compile: state={import.Compile.State}, errors={import.Compile.ErrorCount}, warnings={import.Compile.WarningCount}");
+                LogDiag($"PLC compile: state={import.Compile.State}, errors={CountText(import.Compile.ErrorCount)}, warnings={CountText(import.Compile.WarningCount)}");
             }
 
             McpServer.EnsureUnifiedHmiTagTable("HMI_RT_1", "FlowLightTags");
@@ -166,7 +170,7 @@ namespace TiaMcpServer
             LogHmiTagAttributes("Flow_Enable");
 
             var plcCompile = McpServer.CompileAndDiagnosePlc("PLC_1");
-            LogDiag($"Final PLC compile: state={plcCompile.State}, errors={plcCompile.ErrorCount}, warnings={plcCompile.WarningCount}");
+            LogDiag($"Final PLC compile: state={plcCompile.State}, errors={CountText(plcCompile.ErrorCount)}, warnings={CountText(plcCompile.WarningCount)}");
             foreach (var e in plcCompile.Errors ?? Array.Empty<string>()) LogDiag("Final PLC compile error: " + e);
             foreach (var w in plcCompile.Warnings ?? Array.Empty<string>()) LogDiag("Final PLC compile warning: " + w);
 
@@ -1293,7 +1297,7 @@ namespace TiaMcpServer
             foreach (var failure in plcImport.Failed ?? Array.Empty<ImportFailure>())
                 LogDiag($"PLC import failure: {failure.Path} :: {failure.Error}");
             if (plcImport.Compile != null)
-                LogDiag($"PLC import compile: {plcImport.Compile.State}, errors={plcImport.Compile.ErrorCount}, warnings={plcImport.Compile.WarningCount}");
+                LogDiag($"PLC import compile: {plcImport.Compile.State}, errors={CountText(plcImport.Compile.ErrorCount)}, warnings={CountText(plcImport.Compile.WarningCount)}");
 
             var symbolicTagPath = Path.Combine(importDir, "ClassicHmiTagTable_Symbolic.xml");
             WriteClassicHmiSymbolicTagTableProbeXml(symbolicTagPath, "Motor_HMI_Tags", "HMI_Connection_1");
@@ -1395,7 +1399,7 @@ namespace TiaMcpServer
 
             if (import.Compile != null)
             {
-                LogDiag($"PLC syntax import compile: state={import.Compile.State}, errors={import.Compile.ErrorCount}, warnings={import.Compile.WarningCount}");
+                LogDiag($"PLC syntax import compile: state={import.Compile.State}, errors={CountText(import.Compile.ErrorCount)}, warnings={CountText(import.Compile.WarningCount)}");
             }
 
             var sourceImported = false;
@@ -1427,20 +1431,27 @@ namespace TiaMcpServer
                 if (sourceGenerated)
                 {
                     var sourceCompile = McpServer.CompileAndDiagnosePlc(softwarePath);
-                    LogDiag($"PLC SCL source compile: state={sourceCompile.State}, errors={sourceCompile.ErrorCount}, warnings={sourceCompile.WarningCount}");
+                    LogDiag($"PLC SCL source compile: state={sourceCompile.State}, errors={CountText(sourceCompile.ErrorCount)}, warnings={CountText(sourceCompile.WarningCount)}");
                     foreach (var e in sourceCompile.Errors ?? Array.Empty<string>()) LogDiag("PLC SCL source error: " + e);
                     foreach (var w in sourceCompile.Warnings ?? Array.Empty<string>()) LogDiag("PLC SCL source warning: " + w);
                 }
             }
 
             var compile = McpServer.CompileAndDiagnosePlc(softwarePath);
-            LogDiag($"PLC syntax validation compile: state={compile.State}, errors={compile.ErrorCount}, warnings={compile.WarningCount}");
+            LogDiag($"PLC syntax validation compile: state={compile.State}, errors={CountText(compile.ErrorCount)}, warnings={CountText(compile.WarningCount)}");
             foreach (var e in compile.Errors ?? Array.Empty<string>()) LogDiag("PLC syntax validation error: " + e);
             foreach (var w in compile.Warnings ?? Array.Empty<string>()) LogDiag("PLC syntax validation warning: " + w);
 
-            if ((compile.ErrorCount ?? 0) > 0 || (import.Failed?.Any() ?? false))
+            // 三态：true=确实零错误，false=确实有错误，null=编译结果没读回来。
+            // null 不能当成通过（原来的 ?? 0 就是这么放行的），但要和"真有错误"分开报，先判真失败保证原文案不变。
+            bool? syntaxClean = compile.ErrorCount == null ? (bool?)null : compile.ErrorCount.Value == 0;
+            if (syntaxClean == false || (import.Failed?.Any() ?? false))
             {
                 throw new InvalidOperationException($"PLC SCL syntax validation failed. ImportDir: {importDir}");
+            }
+            if (syntaxClean == null)
+            {
+                throw new InvalidOperationException($"PLC SCL syntax validation NOT verified: compile result unreadable (ErrorCount unavailable). ImportDir: {importDir}");
             }
 
             var save = McpServer.SaveProject();
@@ -1507,15 +1518,21 @@ namespace TiaMcpServer
             var import = McpServer.ImportPlcProgramFromDirectory("PLC_1", importDir, compileAfter: true, stopOnImportFailure: false);
             LogDiag($"PLC import: types={string.Join(",", import.ImportedTypes ?? Array.Empty<string>())}, tags={string.Join(",", import.ImportedTagTables ?? Array.Empty<string>())}, blocks={string.Join(",", import.ImportedBlocks ?? Array.Empty<string>())}, failed={import.Failed?.Count() ?? 0}");
             foreach (var failure in import.Failed ?? Array.Empty<ImportFailure>()) LogDiag($"PLC import failure: {failure.Path} :: {failure.Error}");
-            if (import.Compile != null) LogDiag($"PLC import compile: {import.Compile.State}, errors={import.Compile.ErrorCount}, warnings={import.Compile.WarningCount}");
+            if (import.Compile != null) LogDiag($"PLC import compile: {import.Compile.State}, errors={CountText(import.Compile.ErrorCount)}, warnings={CountText(import.Compile.WarningCount)}");
 
             var compile = McpServer.CompileAndDiagnosePlc("PLC_1");
-            LogDiag($"Final PLC compile: state={compile.State}, errors={compile.ErrorCount}, warnings={compile.WarningCount}");
+            LogDiag($"Final PLC compile: state={compile.State}, errors={CountText(compile.ErrorCount)}, warnings={CountText(compile.WarningCount)}");
             foreach (var e in compile.Errors ?? Array.Empty<string>()) LogDiag("PLC compile error: " + e);
             foreach (var w in compile.Warnings ?? Array.Empty<string>()) LogDiag("PLC compile warning: " + w);
-            if ((compile.ErrorCount ?? 0) > 0)
+            // 同上三态：读不回编译结果同样不放行，但文案与"真有错误"分开。
+            bool? compileClean = compile.ErrorCount == null ? (bool?)null : compile.ErrorCount.Value == 0;
+            if (compileClean == false)
             {
                 throw new InvalidOperationException("PLC compile failed. See log/importDir: " + importDir);
+            }
+            if (compileClean == null)
+            {
+                throw new InvalidOperationException("PLC compile NOT verified: compile result unreadable (ErrorCount unavailable). See log/importDir: " + importDir);
             }
 
             if (hmi.Ok == true)

--- a/tools/tiaportal-mcp/src/TiaMcpServer/Program.HmiTemplates.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/Program.HmiTemplates.cs
@@ -868,9 +868,17 @@ END_DATA_BLOCK
                     try
                     {
                         var tag = currentTags.FirstOrDefault(x => string.Equals(x.Name, tagName, StringComparison.OrdinalIgnoreCase));
-                        McpServer.BindUnifiedHmiTagDynamization("HMI_RT_1", screenName, itemName, propertyName, tagName, tag?.DataType ?? "Bool", tag?.PlcTag ?? "", "");
-                        McpServer.DescribeHmiScreenItem("HMI_RT_1", screenName, itemName, 80);
-                        result["bindingsSucceeded"] = (int)result["bindingsSucceeded"]! + 1;
+                        var bind = McpServer.BindUnifiedHmiTagDynamization("HMI_RT_1", screenName, itemName, propertyName, tagName, tag?.DataType ?? "Bool", tag?.PlcTag ?? "", "");
+                        var itemReadback = McpServer.DescribeHmiScreenItem("HMI_RT_1", screenName, itemName, 80);
+                        var bindFailure = DescribeHmiTagBindingFailure(bind, itemReadback);
+                        if (bindFailure == null)
+                        {
+                            result["bindingsSucceeded"] = (int)result["bindingsSucceeded"]! + 1;
+                        }
+                        else
+                        {
+                            ((List<string>)result["errors"]!).Add($"{itemName}.{propertyName}->{tagName}: {bindFailure}");
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -891,11 +899,17 @@ END_DATA_BLOCK
                         McpServer.EnsureUnifiedHmiButtonEventHandler("HMI_RT_1", screenName, buttonName, eventType);
                         McpServer.SetUnifiedHmiButtonEventScriptCode("HMI_RT_1", screenName, buttonName, eventType, scriptCode, "", false);
                         var readback = McpServer.DescribeUnifiedHmiButtonEventScript("HMI_RT_1", screenName, buttonName, eventType, 80);
-                        if ((readback.Members?.Any() ?? false) || !string.IsNullOrWhiteSpace(readback.Message))
+                        // 证据接到判据上：回读拿到成员才算事件真的挂上了。
+                        // 只看 Message 不算数 —— 失败路径（Project is null / 找不到 handler）同样带 Message，成员却是空的。
+                        if (readback.Members?.Any() ?? false)
                         {
                             result["eventReadbacks"] = (int)result["eventReadbacks"]! + 1;
+                            result["eventsSucceeded"] = (int)result["eventsSucceeded"]! + 1;
                         }
-                        result["eventsSucceeded"] = (int)result["eventsSucceeded"]! + 1;
+                        else
+                        {
+                            ((List<string>)result["errors"]!).Add($"{buttonName}.{eventType}->{tagName}: UNVERIFIED: event script readback returned no members ({readback.Message ?? "no readback result"})");
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -1020,6 +1034,46 @@ END_DATA_BLOCK
             if (meta["success"] is JsonValue successValue && successValue.TryGetValue<bool>(out var success) && !success) return 1;
             if (meta["failed"] is JsonArray failed) return failed.Count;
             return 0;
+        }
+
+        // 绑定判据：BindUnifiedHmiTagDynamization "没抛异常" 不等于绑上了。
+        // Portal 侧 RunHmiStepTool 把异常吞成 Meta["success"]=false + Meta["error"]；而属性名不被控件接受时
+        // 连异常都没有，只在 Meta["setTag"]=false 里如实报出来。所以硬证据是 Meta 的 success + setTag 两个字段。
+        // 返回 null = 确实挂上了；返回字符串 = 没挂上（或没能验证）的原因，附上实际读到的内容。
+        private static string? DescribeHmiTagBindingFailure(ResponseMessage? bind, ResponseObjectDescribe? readback)
+        {
+            var meta = bind?.Meta;
+            if (meta == null)
+            {
+                return "binding returned no Meta evidence";
+            }
+
+            var evidence = "setTag=" + (meta["setTag"]?.ToString() ?? "(absent)")
+                           + ", action=" + (meta["action"]?.ToString() ?? "(absent)")
+                           + ", dynamizationType=" + (meta["dynamizationType"]?.ToString() ?? "(absent)");
+
+            if (meta["success"] is JsonValue successValue && successValue.TryGetValue<bool>(out var success) && !success)
+            {
+                return "binding failed: " + (meta["error"]?.ToString() ?? bind?.Message ?? "(no error detail)") + " [" + evidence + "]";
+            }
+
+            if (!(meta["setTag"] is JsonValue setTagValue && setTagValue.TryGetValue<bool>(out var setTag)))
+            {
+                return "binding reported no setTag evidence [" + evidence + "]";
+            }
+
+            if (!setTag)
+            {
+                return "Tag property was not accepted by the control [" + evidence + "]";
+            }
+
+            // 回读读不回来既不算绑定失败也不算成功：显式标 UNVERIFIED，不许静默吞掉当成功。
+            if (readback?.Members == null || !readback.Members.Any())
+            {
+                return "UNVERIFIED: screen item readback returned no members (" + (readback?.Message ?? "no readback result") + ") [" + evidence + "]";
+            }
+
+            return null;
         }
 
         private static void RunValidateMappedHmiTemplateBindings(CliOptions options)
@@ -1330,9 +1384,17 @@ END_DATA_BLOCK
                 try
                 {
                     var tag = currentTags.FirstOrDefault(x => string.Equals(x.Name, tagName, StringComparison.OrdinalIgnoreCase));
-                    McpServer.BindUnifiedHmiTagDynamization("HMI_RT_1", screenName, itemName, propertyName, tagName, tag?.DataType ?? "Bool", tag?.PlcTag ?? "", "");
-                    McpServer.DescribeHmiScreenItem("HMI_RT_1", screenName, itemName, 80);
-                    result["bindingsSucceeded"] = (int)result["bindingsSucceeded"]! + 1;
+                    var bind = McpServer.BindUnifiedHmiTagDynamization("HMI_RT_1", screenName, itemName, propertyName, tagName, tag?.DataType ?? "Bool", tag?.PlcTag ?? "", "");
+                    var itemReadback = McpServer.DescribeHmiScreenItem("HMI_RT_1", screenName, itemName, 80);
+                    var bindFailure = DescribeHmiTagBindingFailure(bind, itemReadback);
+                    if (bindFailure == null)
+                    {
+                        result["bindingsSucceeded"] = (int)result["bindingsSucceeded"]! + 1;
+                    }
+                    else
+                    {
+                        ((List<string>)result["errors"]!).Add($"{itemName}.{propertyName}->{tagName}: {bindFailure}");
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -1353,11 +1415,17 @@ END_DATA_BLOCK
                     McpServer.EnsureUnifiedHmiButtonEventHandler("HMI_RT_1", screenName, buttonName, eventType);
                     McpServer.SetUnifiedHmiButtonEventScriptCode("HMI_RT_1", screenName, buttonName, eventType, scriptCode, "", false);
                     var readback = McpServer.DescribeUnifiedHmiButtonEventScript("HMI_RT_1", screenName, buttonName, eventType, 80);
-                    if ((readback.Members?.Any() ?? false) || !string.IsNullOrWhiteSpace(readback.Message))
+                    // 证据接到判据上：回读拿到成员才算事件真的挂上了。
+                    // 只看 Message 不算数 —— 失败路径（Project is null / 找不到 handler）同样带 Message，成员却是空的。
+                    if (readback.Members?.Any() ?? false)
                     {
                         result["eventReadbacks"] = (int)result["eventReadbacks"]! + 1;
+                        result["eventsSucceeded"] = (int)result["eventsSucceeded"]! + 1;
                     }
-                    result["eventsSucceeded"] = (int)result["eventsSucceeded"]! + 1;
+                    else
+                    {
+                        ((List<string>)result["errors"]!).Add($"{buttonName}.{eventType}->{tagName}: UNVERIFIED: event script readback returned no members ({readback.Message ?? "no readback result"})");
+                    }
                 }
                 catch (Exception ex)
                 {

--- a/tools/tiaportal-mcp/src/TiaMcpServer/Program.PlcHmiSyncXml.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/Program.PlcHmiSyncXml.cs
@@ -58,10 +58,17 @@ namespace TiaMcpServer
 
             var import = McpServer.ImportPlcProgramFromDirectory("PLC_1", importDir, compileAfter: true, stopOnImportFailure: true);
             var compile = McpServer.CompileAndDiagnosePlc("PLC_1");
-            if ((compile.ErrorCount ?? 0) > 0 || (import.Failed?.Any() ?? false))
+            // 三态：ErrorCount==null 表示编译结果没读回来，不是零错误——不放行，但报告和异常文案要和"真有错误"分开。
+            bool? compileClean = compile.ErrorCount == null ? (bool?)null : compile.ErrorCount.Value == 0;
+            if (compileClean == false || (import.Failed?.Any() ?? false))
             {
                 WritePlcHmiSyncReport(reportPath, jsonReportPath, projectName, projectDirectory, importDir, false, "", expected, import, compile, new List<Dictionary<string, object?>>(), "PLC import or compile failed.");
                 throw new InvalidOperationException("PLC/HMI sync minimal validation failed during PLC compile. Report: " + reportPath);
+            }
+            if (compileClean == null)
+            {
+                WritePlcHmiSyncReport(reportPath, jsonReportPath, projectName, projectDirectory, importDir, false, "", expected, import, compile, new List<Dictionary<string, object?>>(), "PLC compile result unreadable (ErrorCount unavailable); compile NOT verified.");
+                throw new InvalidOperationException("PLC/HMI sync minimal validation NOT verified: compile result unreadable (ErrorCount unavailable). Report: " + reportPath);
             }
 
             var exportedTagTable = Path.Combine(reportDir, "Sync_Minimal_Tags_export.xml");
@@ -277,7 +284,7 @@ namespace TiaMcpServer
             md.AppendLine("- ProjectDirectory: `" + projectDirectory + "`");
             md.AppendLine("- ImportDir: `" + importDir + "`");
             md.AppendLine("- Result: `" + (passed ? "PASS" : "FAIL") + "`");
-            md.AppendLine("- PLC Compile: `errors=" + compile.ErrorCount + ", warnings=" + compile.WarningCount + ", state=" + compile.State + "`");
+            md.AppendLine("- PLC Compile: `errors=" + CountText(compile.ErrorCount) + ", warnings=" + CountText(compile.WarningCount) + ", state=" + compile.State + "`");
             if (!string.IsNullOrWhiteSpace(connectionReadback)) md.AppendLine("- HMI Connection: `" + connectionReadback.Replace("`", "'") + "`");
             if (!string.IsNullOrWhiteSpace(error)) md.AppendLine("- Error: `" + error.Replace("`", "'") + "`");
             md.AppendLine();
@@ -368,17 +375,22 @@ namespace TiaMcpServer
             };
             var importedBlockNames = import.ImportedBlocks ?? Array.Empty<string>();
             var exportedFileNames = exportedFiles.Select(Path.GetFileNameWithoutExtension).Where(n => !string.IsNullOrWhiteSpace(n)).ToArray();
-            var passed = (compile.ErrorCount ?? 0) == 0
-                && importedBlockNames.Any(n => string.Equals(n, "FB1_LAD_Motor", StringComparison.OrdinalIgnoreCase))
+            // 三态：ErrorCount==null 表示编译结果没读回来，原来的 ?? 0 会让 passed 直接为 true。
+            bool? compileClean = compile.ErrorCount == null ? (bool?)null : compile.ErrorCount.Value == 0;
+            var otherChecksPassed = importedBlockNames.Any(n => string.Equals(n, "FB1_LAD_Motor", StringComparison.OrdinalIgnoreCase))
                 && importedBlockNames.Any(n => string.Equals(n, "FB2_SCL_Count", StringComparison.OrdinalIgnoreCase))
                 && exportedFileNames.Any(n => string.Equals(n, "FB1_LAD_Motor", StringComparison.OrdinalIgnoreCase))
                 && exportedFileNames.Any(n => string.Equals(n, "FB2_SCL_Count", StringComparison.OrdinalIgnoreCase))
                 && checks.Values.All(v => v);
+            var passed = compileClean == true && otherChecksPassed;
             McpServer.SaveProject();
             WriteChineseCommentsReport(reportPath, jsonReportPath, projectName, projectDirectory, importDir, exportDir, passed, import, compile, checks, exportedFiles);
             if (!passed)
             {
-                throw new InvalidOperationException("PLC Chinese comments validation failed. Report: " + reportPath);
+                // 只有"其余检查都过、单单编译结果读不回来"才换文案；任何真失败仍走原文案。
+                throw new InvalidOperationException(otherChecksPassed && compileClean == null
+                    ? "PLC Chinese comments validation NOT verified: compile result unreadable (ErrorCount unavailable). Report: " + reportPath
+                    : "PLC Chinese comments validation failed. Report: " + reportPath);
             }
         }
 
@@ -453,7 +465,7 @@ namespace TiaMcpServer
             md.AppendLine();
             md.AppendLine("- Project: `" + projectName + "`");
             md.AppendLine("- Result: `" + (passed ? "PASS" : "FAIL") + "`");
-            md.AppendLine("- PLC Compile: `errors=" + compile.ErrorCount + ", warnings=" + compile.WarningCount + ", state=" + compile.State + "`");
+            md.AppendLine("- PLC Compile: `errors=" + CountText(compile.ErrorCount) + ", warnings=" + CountText(compile.WarningCount) + ", state=" + compile.State + "`");
             md.AppendLine("- ImportDir: `" + importDir + "`");
             md.AppendLine("- ExportDir: `" + exportDir + "`");
             md.AppendLine();
@@ -547,8 +559,8 @@ namespace TiaMcpServer
             sb.AppendLine();
             sb.AppendLine("Compile:");
             sb.AppendLine("State=" + compile.State);
-            sb.AppendLine("Errors=" + compile.ErrorCount);
-            sb.AppendLine("Warnings=" + compile.WarningCount);
+            sb.AppendLine("Errors=" + CountText(compile.ErrorCount));
+            sb.AppendLine("Warnings=" + CountText(compile.WarningCount));
             var compileErrors = compile.Errors?.ToArray() ?? Array.Empty<string>();
             var compileWarnings = compile.Warnings?.ToArray() ?? Array.Empty<string>();
             if (compileErrors.Length > 0)

--- a/tools/tiaportal-mcp/src/TiaMcpServer/Siemens/Portal.Blocks.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/Siemens/Portal.Blocks.cs
@@ -41,6 +41,58 @@ namespace TiaMcpServer.Siemens
     {
         #region blocks/types
 
+        /// <summary>
+        /// 按名字在一个组里定位**唯一一个**对象。三级次序，专治「返回错块还冠上你请求的名字」：
+        /// 1) 先按字面精确同名（OrdinalIgnoreCase）—— 西门子块名里常带 '.'，而 '.' 在 _regexChars 里，
+        ///    老代码见到 '.' 就直接当正则走，于是请求 "FB_Motor.V2" 会被没锚定的 IsMatch 匹配上
+        ///    "X_FB_MotorAV2_Old"，FirstOrDefault 把排在前面的那个错块返回、调用方还以为拿到的是自己要的；
+        /// 2) 没有同名、且名字确实含元字符时才当模式用，并且**锚定** ^(?:...)$ ——
+        ///    保留模式能力，但杜绝部分命中；正则非法则返回 null（等同找不到，与老行为一致）；
+        /// 3) 锚定后仍命中多个 → 宁可报歧义也不猜（团队在删除口早就拒绝含元字符的路径，
+        ///    读/导出口一直没堵，这里补上）。
+        /// </summary>
+        private T? ResolveSingleByName<T>(IEnumerable<T> items, string name, Func<T, string> nameOf, string kind)
+            where T : class
+        {
+            var exact = items.FirstOrDefault(i => nameOf(i).Equals(name, StringComparison.OrdinalIgnoreCase));
+            if (exact != null)
+            {
+                return exact;
+            }
+
+            if (name.IndexOfAny(_regexChars) < 0)
+            {
+                return null;
+            }
+
+            Regex regex;
+            try
+            {
+                regex = new Regex($"^(?:{name})$", RegexOptions.IgnoreCase);
+            }
+            catch (Exception)
+            {
+                // Invalid regex, return null
+                return null;
+            }
+
+            // 匹配与抛歧义都放在 try 之外：否则「歧义」这个异常会被上面捕获非法正则的 catch 吞成 null。
+            var matches = items.Where(i => regex.IsMatch(nameOf(i))).Take(11).ToList();
+            if (matches.Count == 0)
+            {
+                return null;
+            }
+            if (matches.Count > 1)
+            {
+                var candidates = matches.Take(10).Select(nameOf).ToList();
+                throw new PortalException(PortalErrorCode.InvalidParams,
+                    $"Ambiguous {kind} name '{name}': it matched {(matches.Count > 10 ? "more than 10" : matches.Count.ToString())} {kind}s. Use the exact path instead.",
+                    candidates);
+            }
+
+            return matches[0];
+        }
+
         public PlcBlock? GetBlock(string softwarePath, string blockPath)
         {
             _logger?.LogInformation($"Getting block by path: {blockPath}");
@@ -60,30 +112,10 @@ namespace TiaMcpServer.Siemens
                     var path = blockPath.Contains("/") ? blockPath.Substring(0, blockPath.LastIndexOf("/")) : string.Empty;
                     var regexName = blockPath.Contains("/") ? blockPath.Substring(blockPath.LastIndexOf("/") + 1) : blockPath;
 
-                    PlcBlock? block = null;
-
                     var group = GetPlcBlockGroupByPath(softwarePath, path);
                     if (group != null)
                     {
-                        if (regexName.IndexOfAny(_regexChars) >= 0)
-                        {
-                            try
-                            {
-                                var regex = new Regex(regexName, RegexOptions.IgnoreCase);
-                                block = group.Blocks.FirstOrDefault(b => regex.IsMatch(b.Name)) as PlcBlock;
-                            }
-                            catch (Exception)
-                            {
-                                // Invalid regex, return null
-                                return null;
-                            }
-                        }
-                        else
-                        {
-                            block = group.Blocks.FirstOrDefault(b => b.Name.Equals(regexName, StringComparison.OrdinalIgnoreCase));
-                        }
-
-                        return block;
+                        return ResolveSingleByName(group.Blocks.Cast<PlcBlock>(), regexName, b => b.Name, "block");
                     }
                 }
             }
@@ -110,30 +142,10 @@ namespace TiaMcpServer.Siemens
                     var path = typePath.Contains("/") ? typePath.Substring(0, typePath.LastIndexOf("/")) : string.Empty;
                     var regexName = typePath.Contains("/") ? typePath.Substring(typePath.LastIndexOf("/") + 1) : typePath;
 
-                    PlcType? type = null;
-
                     var group = GetPlcTypeGroupByPath(softwarePath, path);
                     if (group != null)
                     {
-                        if (regexName.IndexOfAny(_regexChars) >= 0)
-                        {
-                            try
-                            {
-                                var regex = new Regex(regexName, RegexOptions.IgnoreCase);
-                                type = group.Types.FirstOrDefault(t => regex.IsMatch(t.Name)) as PlcType;
-                            }
-                            catch (Exception)
-                            {
-                                // Invalid regex, return null
-                                return null;
-                            }
-                        }
-                        else
-                        {
-                            type = group.Types.FirstOrDefault(t => t.Name.Equals(regexName, StringComparison.OrdinalIgnoreCase));
-                        }
-
-                        return type;
+                        return ResolveSingleByName(group.Types.Cast<PlcType>(), regexName, t => t.Name, "type");
                     }
                 }
             }

--- a/tools/tiaportal-mcp/src/TiaMcpServer/Siemens/Portal.Helpers.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/Siemens/Portal.Helpers.cs
@@ -598,6 +598,11 @@ namespace TiaMcpServer.Siemens
 
         private SoftwareContainer? GetSoftwareContainer(string softwarePath)
         {
+            // 清空点必须在这里、不能放到 ResolveSoftwareContainerUncached 里：下面有缓存，
+            // 命中缓存时根本不进 Uncached，在那里清会让上一次的错误跨调用残留，
+            // 把一次早已成功的解析说成"遍历出错"。放在入口＝每次对外解析都从干净状态开始。
+            _deviceScanFirstError = null;
+
             if (_project == null)
             {
                 if (_softwareCacheProject != null) { _softwareContainerCache.Clear(); _softwareCacheProject = null; }
@@ -720,6 +725,34 @@ namespace TiaMcpServer.Siemens
             return null;
         }
 
+        /// <summary>
+        /// 遍历设备树时被吞掉的首个异常（"位置: 异常类型: message"），没有则为 null。
+        /// 为什么要存这么一份：FindFirstSoftwareContainer 是静态方法、返回值又只有
+        /// SoftwareContainer?，改签名会波及大量调用点；把真因暂存在这里，才能在不动签名的
+        /// 前提下让上层的"找不到 PLC"消息说出真话，而不是让用户去改一个本来就对的路径。
+        /// [ThreadStatic]：Openness 调用按线程走，避免并发会话互相串消息。
+        /// </summary>
+        [ThreadStatic]
+        private static string? _deviceScanFirstError;
+
+        /// <summary>
+        /// 只记首个：后续异常多半是同一个代理故障的连锁反应，首个最接近真因。
+        /// </summary>
+        private static void RecordDeviceScanError(string where, Exception ex)
+        {
+            _deviceScanFirstError ??= $"{where}: {ex.GetType().Name}: {ex.Message}";
+        }
+
+        /// <summary>
+        /// 供"找不到 PLC"一类消息拼接的后缀；本次解析没有吞过异常时返回空串
+        /// （保证遍历正常时消息与以前逐字节相同）。
+        /// </summary>
+        public string DeviceScanErrorSuffix()
+        {
+            var err = _deviceScanFirstError;
+            return string.IsNullOrEmpty(err) ? string.Empty : " Device tree scan error: " + err;
+        }
+
         private static SoftwareContainer? FindFirstSoftwareContainer(IEnumerable<DeviceItem> roots, string? preferName)
         {
             try
@@ -749,11 +782,29 @@ namespace TiaMcpServer.Siemens
                                 if (ch != null) stack.Push(ch);
                         }
                     }
-                    catch { }
+                    catch (Exception ex)
+                    {
+                        // 这里抛异常＝整棵子树被静默剪掉，PLC 可能就在被剪掉的那半边。
+                        // 继续遍历其余分支（保持原行为），但把真因留下。
+                        RecordDeviceScanError("DeviceItems(" + (TryGetDeviceItemName(it) ?? "?") + ")", ex);
+                    }
                 }
             }
-            catch { }
+            catch (Exception ex)
+            {
+                // 这里抛异常＝整次遍历被静默中止，结果一定是"找不到"，必须留下真因。
+                RecordDeviceScanError("DeviceTreeScan", ex);
+            }
             return null;
+        }
+
+        /// <summary>
+        /// 取 DeviceItem 名字用于错误定位；读 Name 本身也可能抛（代理已失效），所以再包一层。
+        /// </summary>
+        private static string? TryGetDeviceItemName(DeviceItem item)
+        {
+            try { return item.Name; }
+            catch { return null; }
         }
 
         private SoftwareContainer? GetSoftwareContainerInGroups(DeviceUserGroupComposition groups, string[] pathSegments, int index)
@@ -1522,7 +1573,9 @@ namespace TiaMcpServer.Siemens
                         }
                     }
                     catch { }
-                    return TryFindByNameInCollection(tagsComp, Array.Empty<string>(), tagName);
+                    // 原来这里还有一层 TryFindByNameInCollection(tagsComp, Array.Empty<string>(), ...) 的"兜底"，
+                    // 但该方法只遍历 propertyHints，空数组＝循环体一次不进＝恒返回 null，是死代码。
+                    return null;
                 }
 
                 case "hmiconnection":
@@ -1538,7 +1591,8 @@ namespace TiaMcpServer.Siemens
                     if (sc?.Software == null) return null;
                     var conns = TryGetPropertyValue(sc.Software, "Connections");
                     if (conns == null) return null;
-                    return FindExistingByName(conns, connectionName) ?? TryFindByNameInCollection(conns, Array.Empty<string>(), connectionName);
+                    // 去掉 ?? TryFindByNameInCollection(conns, Array.Empty<string>(), ...)：空 hints 恒返回 null。
+                    return FindExistingByName(conns, connectionName);
                 }
 
                 case "hmiscreenitem":

--- a/tools/tiaportal-mcp/src/TiaMcpServer/Siemens/Portal.Software.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/Siemens/Portal.Software.cs
@@ -126,9 +126,13 @@ namespace TiaMcpServer.Siemens
             try
             {
                 var names = GetAllPlcSoftware().Select(p => p.Name).Where(n => !string.IsNullOrWhiteSpace(n)).Distinct().ToList();
-                return names.Count > 0 ? " Available PLC paths: " + string.Join(", ", names) : string.Empty;
+                var paths = names.Count > 0 ? " Available PLC paths: " + string.Join(", ", names) : string.Empty;
+                // 附上设备树遍历中被吞掉的真因：路径其实是对的、只是遍历半途抛了的那种情况，
+                // 光报 "Available PLC paths" 会把用户引去改一个本来就没错的参数。
+                // 遍历正常时 DeviceScanErrorSuffix() 返回空串，消息与以前逐字节相同。
+                return paths + DeviceScanErrorSuffix();
             }
-            catch { return string.Empty; }
+            catch { return DeviceScanErrorSuffix(); }
         }
 
         /// <summary>
@@ -1532,10 +1536,8 @@ namespace TiaMcpServer.Siemens
             }
             catch { }
 
-            if (tagObj == null)
-            {
-                tagObj = TryFindByNameInCollection(tagsComp, Array.Empty<string>(), tagName);
-            }
+            // 原来这里还有一次 TryFindByNameInCollection(tagsComp, Array.Empty<string>(), tagName) 的"兜底"，
+            // 该方法只遍历 propertyHints，空数组＝循环体一次不进＝恒返回 null，纯死代码，已删。
 
             if (tagObj == null)
             {
@@ -1773,7 +1775,8 @@ namespace TiaMcpServer.Siemens
                     try
                     {
                         // find existing
-                        var exists = FindExistingByName(tagsComp, tn) ?? TryFindByNameInCollection(tagsComp, Array.Empty<string>(), tn);
+                        // 去掉 ?? TryFindByNameInCollection(tagsComp, Array.Empty<string>(), ...)：空 hints 恒返回 null。
+                        var exists = FindExistingByName(tagsComp, tn);
                         if (exists != null)
                         {
                             var wr = new JsonArray();
@@ -2616,7 +2619,8 @@ namespace TiaMcpServer.Siemens
                 var tags = TryGetPropertyValue(tagTable, "Tags");
                 if (tags == null) throw new InvalidOperationException($"Tags collection not found on tag table '{tagTableName}'.");
 
-                var tag = FindExistingByName(tags, tagName) ?? TryFindByNameInCollection(tags, Array.Empty<string>(), tagName);
+                // 去掉 ?? TryFindByNameInCollection(tags, Array.Empty<string>(), ...)：空 hints 恒返回 null。
+                var tag = FindExistingByName(tags, tagName);
                 var action = "exists";
                 if (tag == null)
                 {
@@ -2657,7 +2661,8 @@ namespace TiaMcpServer.Siemens
             var connections = TryGetPropertyValue(sw, "Connections");
             if (connections == null) throw new InvalidOperationException($"Connections collection not found on HMI software '{hmiSoftwarePath}'.");
 
-            var connection = FindExistingByName(connections, connectionName) ?? TryFindByNameInCollection(connections, Array.Empty<string>(), connectionName);
+            // 去掉 ?? TryFindByNameInCollection(connections, Array.Empty<string>(), ...)：空 hints 恒返回 null。
+            var connection = FindExistingByName(connections, connectionName);
             if (connection == null)
             {
                 var create = connections.GetType().GetMethod("Create", new[] { typeof(string) });
@@ -4662,7 +4667,8 @@ namespace TiaMcpServer.Siemens
             var connections = TryGetPropertyValue(sw, "Connections");
             if (connections == null) throw new PortalException(PortalErrorCode.NotFound, $"HMI Connections collection not found on '{softwarePath}'");
 
-            var connection = FindExistingByName(connections, connectionName) ?? TryFindByNameInCollection(connections, Array.Empty<string>(), connectionName);
+            // 去掉 ?? TryFindByNameInCollection(connections, Array.Empty<string>(), ...)：空 hints 恒返回 null。
+            var connection = FindExistingByName(connections, connectionName);
             if (connection == null) throw new PortalException(PortalErrorCode.NotFound, $"HMI connection not found: {connectionName}");
 
             if (!TryExportEngineeringObject(connection, exportPath, out var err))
@@ -4699,7 +4705,8 @@ namespace TiaMcpServer.Siemens
                 ?? FindTypeBySuffix("Communication.Connection");
             sb.AppendLine("ConnectionType=" + (connectionType?.FullName ?? "<not found>"));
 
-            var existing = FindExistingByName(connections, connectionName) ?? TryFindByNameInCollection(connections, Array.Empty<string>(), connectionName);
+            // 去掉 ?? TryFindByNameInCollection(connections, Array.Empty<string>(), ...)：空 hints 恒返回 null。
+            var existing = FindExistingByName(connections, connectionName);
             if (existing != null)
             {
                 sb.AppendLine("ExistingConnection=" + connectionName);
@@ -4765,7 +4772,8 @@ namespace TiaMcpServer.Siemens
                 }
             }
 
-            created ??= FindExistingByName(connections, connectionName) ?? TryFindByNameInCollection(connections, Array.Empty<string>(), connectionName);
+            // 去掉 ?? TryFindByNameInCollection(connections, Array.Empty<string>(), ...)：空 hints 恒返回 null。
+            created ??= FindExistingByName(connections, connectionName);
             if (created == null)
             {
                 sb.AppendLine("Readback=FAIL :: connection not found after create attempts");

--- a/tools/tiaportal-mcp/src/TiaMcpServer/Siemens/Portal.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/Siemens/Portal.cs
@@ -188,6 +188,23 @@ namespace TiaMcpServer.Siemens
             return result;
         }
 
+        // 判断一个 attach 失败是不是"白名单/授权被拒"（Openness 用户组、授权白名单）。
+        // 这类拒绝跟具体是哪个 Portal 进程无关——换下一个候选、乃至自己新起一个实例，
+        // 结果都一样被拒。用类型名字符串匹配而不是 catch 具体类型：
+        // EngineeringSecurityException 来自运行时解析的 Openness 程序集（V20/V21 两套 csproj），
+        // 不引入编译期依赖更稳。沿 InnerException 链走，因为它常被
+        // EngineeringTargetInvocationException 之类包一层。
+        private static bool IsSecurityRefusal(Exception? ex)
+        {
+            var e = ex;
+            while (e != null)
+            {
+                if (e.GetType().Name == "EngineeringSecurityException") return true;
+                e = e.InnerException;
+            }
+            return false;
+        }
+
         public bool ConnectPortal()
         {
             _logger?.LogInformation("Connecting to TIA Portal...");
@@ -271,6 +288,26 @@ namespace TiaMcpServer.Siemens
                         {
                             _logger?.LogWarning(ex, $"Attach failed for TIA Portal PID={proc.Id}");
                             LastConnectError = ex.ToString();
+
+                            // "这个候选连不上"（忙 / attach 超时 / 没有工程）可以换下一个；
+                            // 但白名单/授权被拒换谁都一样，继续扫毫无意义且有害：扫空所有候选后
+                            // 会落到下面"新起一个无头 TIA 实例"，那次同样被拒，却在用户机器上
+                            // 留下一个空转的孤儿 Siemens.Automation.Portal 进程。所以当场原样重抛，
+                            // 让调用方拿到真因而不是"没有可 attach 的实例"。
+                            if (IsSecurityRefusal(ex))
+                            {
+                                // 先释放此前记下的可 attach 候选——已经不会有人用它了。
+                                // 置 null 后，当前候选（若正是它）也能被 finally 正常释放，不漏 COM 引用。
+                                if (firstAttachable != null)
+                                {
+                                    if (firstAttachable != candidate)
+                                    {
+                                        try { firstAttachable.Dispose(); } catch { }
+                                    }
+                                    firstAttachable = null;
+                                }
+                                throw;
+                            }
                         }
                         finally
                         {


### PR DESCRIPTION
fix: 假绿灯、被吞的失败、指向不存在工具的描述

一批"从上线起就没按自己声称的方式工作"的缺陷。共同点是**失败不会被看见**：
要么把读不回来的结果当成通过，要么把异常吞掉换成一句错的具体结论，要么让模型
照着描述去调一个根本没注册的工具。用户看到的都是绿灯。

## 编译结果读不回来 ≠ 零错误

`ResponseCompile.ErrorCount` 是 `int?`，`null` 专门表示"编译结果没读回来"。
五处写成 `(ErrorCount ?? 0) == 0`，把读不到直接算成编译干净：
`Program.CliProbes.cs` ×2（对外报"语法校验通过"）、`Program.PlcHmiSyncXml.cs` ×2
（报告 `passed=true`）、`Cli/CliCommands.cs` 的 `tia compile`（**进程退 0**，
脚本和 CI 会据此认为编译干净）。
改成三态：读不回来一律不算通过，且文案与"有错误"分开（NOT verified / unreadable），
真有错误时的行为和文案一字未动。顺带把报告里 `errors=` 后面打空白的地方改成
`(unreadable)` —— 空白读起来就像零。

## 块名匹配会返回**错块**

`Portal.Blocks.cs` 的 `GetBlock` / `GetType`：名字里含元字符就整段当正则，
`IsMatch` 不锚定 + `FirstOrDefault` 取排在前面的。而西门子块名常带 `.`，
于是请求 `FB_Motor.V2` 会命中 `X_FB_MotorAV2_Old`，**错块被以你请求的块名标注返回**，
调用方无从察觉；导出、交叉引用都跟着挂到错误对象上。
改成三级：字面精确同名优先（带 `.` 的真实块名从此走这条）→ 无同名且确实含元字符时
按 `^(?:pattern)$` 锚定 → 锚定后多命中报歧义并列候选，不再静默取第一个。
列表过滤那批不锚定是设计意图，未动。

## 「执行 JSON 检查」是恒真的同义反复

`HmiTemplateLayoutAnalyzer` 的检查委托缺省时退化成 `items.Length > 0 && errors.Count == 0`
—— 判据里已经含着 `errors.Count == 0`，**永远不可能新增一条错误**。
走这条空转路径的正是：MCP 工具 `AnalyzeUnifiedHmiTemplateLayout`（描述明确承诺检查
"execution JSON shape"）和 `OfflineReleaseValidationSuite`（发版前的离线验收闸，
报 ok=true 而执行 JSON 构建路径一次都没跑过）。
委托改为必填（编译期堵死这条路），真检查下沉进分析器本身。

## 批量 HMI 绑定：调了回读，然后把结果扔了

`Program.HmiTemplates.cs` 两处：`BindUnifiedHmiTagDynamization` 之后调了
`DescribeHmiScreenItem` 却直接丢弃返回值，计数器只以"没抛异常"为依据 +1。
而 Portal 层的 `RunHmiStepTool` 会把异常吞成 `Meta["success"]=false` 返回 ——
调用方的 try/catch 永远看不到，属性名不被控件接受时 TIA 也只是静默忽略。
于是绑定一个都没挂上，报告照写"全部成功"。
现在判据只认硬证据：`Meta["success"]` + `Meta["setTag"]` + 回读的 `Members`；
读不回来显式标 UNVERIFIED，不计成功也不冒充成功。按钮事件那边已经采到的
`eventReadbacks` 也接到了真正管闸的 `eventsSucceeded` 上。

## 设备树遍历吞异常 → 把"代理抛了"说成"你路径写错了"

`Portal.Helpers.cs` 的 `FindFirstSoftwareContainer` 里的空 catch 会静默剪掉整棵子树
或中止整次遍历，返回 null，上层随即报 "PLC software not found at 'PLC_1'.
Available PLC paths: …" —— 一个参数错误，叫用户去改一个本来就对的路径。
这条波及所有带 `softwarePath` 的工具。改法不动任何签名：记下首个被吞的异常，
接进已被多处消息拼接的 `AvailablePlcPathsSuffix()`，真因随原消息一起到达用户；
没有异常时后缀为空串，消息逐字节不变。

## 连接被拒 → 制造孤儿 TIA 进程

`Portal.cs` 的候选扫描循环把 `EngineeringSecurityException`（白名单/授权被拒）
也吞成"这个候选不行，换下一个"。扫空之后落到"新起一个无头 TIA 实例"，
那次同样会被拒，**但进程已经拉起来了** —— 用户机器上凭空多一个空转的无头
`Siemens.Automation.Portal`。现在这类拒绝当场重抛真因，不再往下走到新起实例。
候选只是忙 / attach 超时 / 没有工程时，换下一个和新起实例的行为一字未变。

## 描述指向不存在的工具

三个名字被工具描述点名，而全仓 209 个注册工具里一个都没有：
`SetForceTableEntry`（强制写值刻意不对 AI 暴露，安全下线做对了、文字忘了同步）、
`GetCpuOnlineState`、`GetAxisParameters`。模型照着描述去调只会撞 tool-not-found，
而撞上的恰好是安全敏感操作，它接下来会去找别的路子绕。
改成如实说明事实与**真实存在**的替代路径。同时给 `SetWatchTableModifyValue`
补上物理安全提示（8 个不可逆动作里唯一实际驱动物理世界却没有一句警示的）。

## 其它

- 反射工具族（`GetObjectProperty` / `ListObjectChildren` / `InvokeObject` /
  `DescribeService` / `InvokeService`）的 `objectPath` 只写了 "Object path"，
  而同族 `DescribeObject` 写清了不同对象类型该填什么 —— 复制粘贴时漏了，
  模型在这五个工具上必然要试错一次。补齐。
- 清掉一批恒返回 null 的后备分支：`TryFindByNameInCollection(x, Array.Empty<string>(), n)`
  的实现只遍历 propertyHints，传空数组等于循环体一次不进。留着的害处不是性能，
  是让人（和模型）以为这里还有一条后备路径。

## 验证

本仓没有测试工程和 CI，只能靠编译：V21 目标 0 错误、警告数与改动前持平
（唯一那条 CS8602 在 `Runtime/OpcUaLiveReader.cs`，改动前就有，不在本次范围内）。
上述缺陷的行为判据来自同源闭源线上的验证（那边有 880 条离线回归 + 故障注入 +
运行期 tools/list 实测）。

https://claude.ai/code/session_01YDtjoHUo8oTvDw77AfmpA9
