### PR TITLE
fix: 路径写错报「成功，0 个块」等三条（真机验证）+ 最小离线自检套件与 CI

### DIFF
--- a/.github/workflows/offline-checks.yml
+++ b/.github/workflows/offline-checks.yml
@@ -1,0 +1,35 @@
+name: offline-checks
+
+# 这个仓库的引擎本体编译需要 Siemens.Engineering.dll（要装 TIA Portal），
+# GitHub 托管的 runner 上没有，所以**编译类 CI 在这里不可能有**。
+# 这里跑的是不需要 TIA 的那两类检查：零依赖回归用例，和面向调用方的文案一致性。
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  offline-tests:
+    # 回归套件是**控制台 Exe**，不是 VSTest 工程：
+    # `dotnet test` 在它上面只会还原、一个用例都不跑、然后退 0 ——
+    # 一个和「全部通过」长得一模一样的假绿灯。所以这里写死 `dotnet run`。
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '8.0.x'
+      - name: Offline regression suite
+        run: dotnet run --project tools/tiaportal-mcp/tests/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj -c Release --nologo
+
+  dead-tool-references:
+    # 工具描述里点名的工具必须真的注册过。踩过的形状：某个能力被刻意下线了，
+    # 但两条描述还写着 "use <那个工具>" —— AI 客户端照做只会撞 tool-not-found，
+    # 然后自己去找别的路子绕。纯源码对拍，不需要装 TIA。
+    # 脚本自带必错哨兵：闸门本身坏了会报 FAIL，而不是假 PASS。
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Descriptions must not name unregistered tools
+        run: python3 scripts/Check-DeadToolReferences.py

--- a/scripts/Check-DeadToolReferences.py
+++ b/scripts/Check-DeadToolReferences.py
@@ -1,0 +1,122 @@
+"""面向 Agent 的死引用闸：工具描述里点名的工具，必须真的注册过。
+
+为什么要有这道闸：`GetPlcForceTables` 的描述写着 "use SetForceTableEntry"，而
+`SetForceTableEntry` 从 0.0.38 起就刻意不再注册（强制写值不许 AI 调）。安全下线做对了，
+面向 Agent 的文字忘了同步 —— Agent 照着描述调，撞 "tool not found"，然后自己去找别的
+路子绕，而撞上的恰恰是「强制写值」这种安全敏感操作。同类还查到 `GetAxisParameters`、
+`GetCpuOnlineState` 两个从来不存在的名字。
+
+这类漂移靠人记不住，只能靠对拍：拿引擎实际注册的名字，扫所有 Agent 能看到的文字。
+（同 `SafetyTables.cs` 由 gen 脚本生成的思路：凡是「一份名单必须和代码保持一致」的地方，
+都该走生成或加漂移检查。）
+
+用法：
+    python scripts/Check-DeadToolReferences.py            # 0=干净 1=有死引用
+    python scripts/Check-DeadToolReferences.py --selftest # 哨兵：注入一个假名字，必须被抓到
+"""
+import re
+import io
+import os
+import sys
+import collections
+
+ROOT = 'tools/tiaportal-mcp/src/TiaMcpServer'
+
+# 白名单：形状像工具名、但**不是**本服务器的工具，因此不该被判死引用。
+# 每条必须写明它到底是什么 —— 没有理由的白名单等于把闸门关掉。
+ALLOWED = {
+    # Openness / .NET 的 API 名，描述里是在讲底层调用，不是让 Agent 去调工具
+    'GetService': 'Openness IEngineeringObject.GetService<T>()',
+    'GetAttribute': 'Openness IEngineeringObject.GetAttribute()',
+    'GetAttributeInfos': 'Openness IEngineeringObject.GetAttributeInfos()',
+    'GetSupportedFileFormats': 'Openness Workspace.GetSupportedFileFormats()',
+    'ConnectObject': 'Openness Workspace.ConnectObject()',
+    'ImportDocumentOptions': 'Openness 枚举类型名（importOption 参数的取值来源）',
+    'DownloadProvider': 'Openness DownloadProvider 类型名',
+    'AddSignalBoard': "TIA 里那个操作的俗称，描述原文是「这就是 'InsertDeviceItem' / 'AddSignalBoard' 操作」",
+    # 本仓工具族的通配写法与非工具标识符
+    'BuildPlc': 'BuildPlc* 工具族的通配前缀（BuildPlcUdtXml / BuildPlcObXml / …）',
+    'CompileError': '错误码取值，不是工具名',
+    'RunOut': 'EnsureStartStopUnifiedHmi 建的 HMI 变量名',
+    # 明确写着「本服务器没有这个工具」的说明性提及
+    'DeleteDb': '描述原文即「没有单独的 DeleteDb/DeleteGlobalDb/DeleteFunctionBlock，用 DeletePlcBlock」',
+    'DeleteGlobalDb': '同上',
+    'DeleteFunctionBlock': '同上',
+    'ImportInstanceTexts': '描述原文即 "not yet exposed"',
+}
+
+VERB = re.compile(
+    r'^(Get|Set|Add|Import|Export|Create|Delete|Compile|Download|Sync|Analyze'
+    r'|Build|Write|Read|Ensure|Find|List|Describe|Invoke|Generate|Apply|Bind'
+    r'|Move|Rename|Save|Open|Close|Connect|Run|Check|Validate|Preflight|Scaffold|Attach)[A-Z]')
+STR = r'"[^"]*"'          # 描述文案里没有转义引号，简单形态足够
+LIT = re.compile(r'Description\(\s*((?:@?' + STR + r'\s*\+?\s*)+)\)', re.S)
+PIECE = re.compile(STR)
+TOK = re.compile(r'\b([A-Z][A-Za-z0-9]{3,})\b')
+
+
+def load(root):
+    src = {}
+    for dp, _, fs in os.walk(root):
+        for f in fs:
+            if f.endswith('.cs'):
+                p = os.path.join(dp, f)
+                src[p] = io.open(p, encoding='utf-8-sig', errors='replace').read()
+    return src
+
+
+def scan(src, extra_text=None):
+    """返回 {疑似死引用名: [出处]}。extra_text 供哨兵注入用。"""
+    names = set()
+    for s in src.values():
+        names |= set(re.findall(r'McpServerTool\(Name\s*=\s*"([A-Za-z0-9_]+)"', s))
+    items = list(src.items())
+    if extra_text:
+        items.append(('<sentinel>', extra_text))
+    bad = collections.defaultdict(list)
+    for p, s in items:
+        for m in LIT.finditer(s):
+            text = ' '.join(x[1:-1] for x in PIECE.findall(m.group(1)))
+            line = s[:m.start()].count('\n') + 1
+            for t in set(TOK.findall(text)):
+                if t in names or t in ALLOWED or not VERB.match(t):
+                    continue
+                bad[t].append(os.path.basename(p) + ':' + str(line))
+    return names, bad
+
+
+def main():
+    src = load(ROOT)
+    if not src:
+        print('找不到源码目录 %s —— 请在仓库根目录运行。' % ROOT)
+        return 2
+
+    # 哨兵：注入一个必然不存在的工具名，闸门必须抓到它。
+    # 这条不是形式主义 —— 本仓吃过「检查自己坏了却全绿」的亏（字段读错致全假 PASS）。
+    sentinel = '[McpServerTool(Name = "SentinelTool"), Description("Use GetNonexistentSentinelTool first.")]'
+    _, caught = scan(src, extra_text=sentinel)
+    if 'GetNonexistentSentinelTool' not in caught:
+        print('[FAIL] 哨兵没被抓到 —— 这个检查自己坏了，它的 PASS 不可信。')
+        return 2
+
+    names, bad = scan(src)
+    print('引擎注册工具：%d 个；扫描文件：%d 个' % (len(names), len(src)))
+    if not bad:
+        print('[PASS] 工具描述里点名的工具全部真实注册（哨兵已验证闸门有效）。')
+        return 0
+    print('[FAIL] 下列名字在 [Description] 文案里被点名，但没有任何 [McpServerTool] 注册它：')
+    for t, locs in sorted(bad.items()):
+        print('  %-38s %2d 处  %s' % (t, len(locs), ', '.join(sorted(set(locs))[:4])))
+    print('修法：要么改文案说清事实与替代路径，要么把工具真的注册上。'
+          '若它本就不是工具名，加进本脚本的 ALLOWED 并写明理由。')
+    return 1
+
+
+if __name__ == '__main__':
+    if '--selftest' in sys.argv:
+        src = load(ROOT)
+        _, caught = scan(src, extra_text='[Description("Use GetNonexistentSentinelTool first.")]')
+        ok = 'GetNonexistentSentinelTool' in caught
+        print('哨兵自检：' + ('PASS（假名字被抓到）' if ok else 'FAIL（假名字没被抓到）'))
+        sys.exit(0 if ok else 1)
+    sys.exit(main())

--- a/tools/tiaportal-mcp/src/TiaMcpServer/Siemens/Portal.Blocks.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/Siemens/Portal.Blocks.cs
@@ -186,22 +186,42 @@ namespace TiaMcpServer.Siemens
 
             var list = new List<PlcBlock>();
 
+            // 路径解析不到 ≠ 这个 PLC 里没有块。原来两件事都返回空列表，于是把 softwarePath
+            // 写错也得到「成功，0 个块」—— 调用方（尤其是模型）会据此认为 PLC 是空的，
+            // 转头去建一堆已经存在的块。真机实测过这条：传 'PLC_NOT_EXIST_XYZ' 得到 success=true。
+            var softwareContainer = GetSoftwareContainer(softwarePath);
+            if (softwareContainer?.Software is not PlcSoftware plcSoftware)
+            {
+                throw new PortalException(PortalErrorCode.NotFound,
+                    $"GetBlocks: PLC software not found at '{softwarePath}'." + AvailablePlcPathsSuffix());
+            }
+
+            var group = plcSoftware.BlockGroup;
+            if (group == null)
+            {
+                throw new PortalException(PortalErrorCode.OpennessError,
+                    $"GetBlocks: PLC '{softwarePath}' resolved, but its BlockGroup is not available — "
+                    + "the block list could NOT be read. This is not the same as 'the PLC has no blocks'.");
+            }
+
             try
             {
-                var softwareContainer = GetSoftwareContainer(softwarePath);
-                if (softwareContainer?.Software is PlcSoftware plcSoftware)
-                {
-                    var group = plcSoftware?.BlockGroup;
-
-                    if (group != null)
-                    {
-                        GetBlocksRecursive(group, list, regexName);
-                    }
-                }
+                GetBlocksRecursive(group, list, regexName);
+            }
+            catch (PortalException)
+            {
+                // 参数类错误（比如 regexName 不是合法正则）要原样上抛：包成「遍历失败」
+                // 会给出一个**不准确**的原因，调用方照着去查 Openness 就跑偏了。
+                throw;
             }
             catch (Exception ex)
             {
-                _logger?.LogError(ex, "Error getting blocks");
+                // 遍历炸在半路时原来只记日志、把**残缺的**列表当完整结果返回。
+                // 「少了几个块」比「一个都没有」更难发现，因为它看起来完全正常。
+                throw new PortalException(PortalErrorCode.OpennessError,
+                    $"GetBlocks: block enumeration failed after {list.Count} block(s) in '{softwarePath}'; "
+                    + "the returned list would have been INCOMPLETE, so it is not returned at all. "
+                    + $"Root cause: {ex.Message}", null, ex);
             }
 
             return list;
@@ -244,22 +264,36 @@ namespace TiaMcpServer.Siemens
 
             var list = new List<PlcType>();
 
+            // 与 GetBlocks 同因：路径解析不到 ≠ 这个 PLC 没有 UDT。
+            var softwareContainer = GetSoftwareContainer(softwarePath);
+            if (softwareContainer?.Software is not PlcSoftware plcSoftware)
+            {
+                throw new PortalException(PortalErrorCode.NotFound,
+                    $"GetTypes: PLC software not found at '{softwarePath}'." + AvailablePlcPathsSuffix());
+            }
+
+            var group = plcSoftware.TypeGroup;
+            if (group == null)
+            {
+                throw new PortalException(PortalErrorCode.OpennessError,
+                    $"GetTypes: PLC '{softwarePath}' resolved, but its TypeGroup is not available — "
+                    + "the type list could NOT be read. This is not the same as 'the PLC has no types'.");
+            }
+
             try
             {
-                var softwareContainer = GetSoftwareContainer(softwarePath);
-                if (softwareContainer?.Software is PlcSoftware plcSoftware)
-                {
-                    var group = plcSoftware?.TypeGroup;
-
-                    if (group != null)
-                    {
-                        GetTypesRecursive(group, list, regexName);
-                    }
-                }
+                GetTypesRecursive(group, list, regexName);
+            }
+            catch (PortalException)
+            {
+                throw;   // 同上：参数类错误不许被包成「遍历失败」
             }
             catch (Exception ex)
             {
-                _logger?.LogError(ex, "Error getting user defined types");
+                throw new PortalException(PortalErrorCode.OpennessError,
+                    $"GetTypes: type enumeration failed after {list.Count} type(s) in '{softwarePath}'; "
+                    + "the returned list would have been INCOMPLETE, so it is not returned at all. "
+                    + $"Root cause: {ex.Message}", null, ex);
             }
 
             return list;

--- a/tools/tiaportal-mcp/src/TiaMcpServer/Siemens/Portal.Helpers.cs
+++ b/tools/tiaportal-mcp/src/TiaMcpServer/Siemens/Portal.Helpers.cs
@@ -1380,75 +1380,77 @@ namespace TiaMcpServer.Siemens
             return anySuccess;
         }
 
-        private bool GetBlocksRecursive(PlcBlockGroup group, List<PlcBlock> list, string regexName = "")
+        // 返回值曾经是 bool anySuccess，但它**算了没人看**：两个调用点都丢弃返回值，
+        // 而且子组那一行写的是 `anySuccess = 递归(...)` —— 覆盖而非累积，最终只反映最后一个子组。
+        // 一个既没人读、读了也是错的值，留着只会让人以为这里有个「有没有找到」的信号。
+        private void GetBlocksRecursive(PlcBlockGroup group, List<PlcBlock> list, string regexName = "")
         {
-            var anySuccess = false;
+            // 正则一次编译好。原来是逐块 try/catch：模式写错时每个块都被 catch 掉、
+            // 最后返回空列表，对外表现成「这个 PLC 里没有匹配的块」—— 把「你的模式非法」
+            // 说成了一个具体的、错的事实。
+            var filter = CompileNameFilterOrThrow(regexName);
 
             foreach (var composition in group.Blocks)
             {
                 if (composition is PlcBlock block)
                 {
-                    try
+                    if (filter != null && !filter.IsMatch(block.Name))
                     {
-                        if (!string.IsNullOrEmpty(regexName) && !Regex.IsMatch(block.Name, regexName, RegexOptions.IgnoreCase))
-                        {
-                            continue; // Skip this block if it doesn't match the pattern
-                        }
-                    }
-                    catch (Exception)
-                    {
-                        // Invalid regex pattern, skip this block
-                        continue;
+                        continue; // Skip this block if it doesn't match the pattern
                     }
 
                     list.Add(block);
-
-                    anySuccess = true;
                 }
             }
 
             foreach (var subgroup in group.Groups)
             {
-                anySuccess = GetBlocksRecursive(subgroup, list, regexName);
+                GetBlocksRecursive(subgroup, list, regexName);
             }
-
-            return anySuccess;
         }
 
-        private bool GetTypesRecursive(PlcTypeGroup group, List<PlcType> list, string regexName = "")
+        /// <summary>
+        /// 把 regexName 编成 Regex；空串 = 不过滤（返回 null）。模式非法就当场抛，
+        /// 绝不退化成「一个都没匹配上」—— 那会让调用方以为工程里真的没有这些对象。
+        /// </summary>
+        private static Regex? CompileNameFilterOrThrow(string regexName)
         {
-            var anySuccess = false;
+            if (string.IsNullOrEmpty(regexName)) return null;
+            try
+            {
+                return new Regex(regexName, RegexOptions.IgnoreCase);
+            }
+            catch (ArgumentException ex)
+            {
+                throw new PortalException(PortalErrorCode.InvalidParams,
+                    $"regexName '{regexName}' is not a valid regular expression: {ex.Message}. "
+                    + "Pass an empty string to list everything, or escape the special characters.",
+                    null, ex);
+            }
+        }
+
+        // 与 GetBlocksRecursive 同因：返回值没人读、且子组那行是覆盖不是累积，已去掉。
+        private void GetTypesRecursive(PlcTypeGroup group, List<PlcType> list, string regexName = "")
+        {
+            var filter = CompileNameFilterOrThrow(regexName);
 
             foreach (var composition in group.Types)
             {
                 if (composition is PlcType type)
                 {
-                    try
+                    if (filter != null && !filter.IsMatch(type.Name))
                     {
-                        if (!string.IsNullOrEmpty(regexName) && !Regex.IsMatch(type.Name, regexName, RegexOptions.IgnoreCase))
-                        {
-                            continue; // Skip this block if it doesn't match the pattern
-                        }
-                    }
-                    catch (Exception)
-                    {
-                        // Invalid regex pattern, skip this block
-                        continue;
+                        continue; // Skip this type if it doesn't match the pattern
                     }
 
                     list.Add(type);
-
-                    anySuccess = true;
                 }
-
             }
 
             foreach (PlcTypeGroup subgroup in group.Groups)
             {
-                anySuccess = GetTypesRecursive(subgroup, list, regexName);
+                GetTypesRecursive(subgroup, list, regexName);
             }
-
-            return anySuccess;
         }
 
         #region meta (reflection helpers)

--- a/tools/tiaportal-mcp/tests/TiaMcpServer.Tests/HmiTemplateLayoutExecutionCheckTests.cs
+++ b/tools/tiaportal-mcp/tests/TiaMcpServer.Tests/HmiTemplateLayoutExecutionCheckTests.cs
@@ -1,0 +1,128 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Text.Json.Nodes;
+using TiaMcpServer.ModelContextProtocol;
+
+// ─────────────────────────────────────────────────────────────────────────────
+//  「执行 JSON 检查」不许是复述已知事实的同义反复。
+//
+//  HmiTemplateLayoutAnalyzer 的执行 JSON 检查原来收一个可选委托，委托没传时退化成：
+//      executionJsonChecked = items.Length > 0 && errors.Count == 0
+//  判据里已经含着 errors.Count == 0 —— 这个「检查」永远不可能新增一条错误，
+//  它只是把「前面没报错」再说一遍，然后挂上「已检查」的牌子。
+//
+//  走这条空转路径的是两个最该被验的调用方：
+//   1) MCP 工具 AnalyzeUnifiedHmiTemplateLayout，而它的描述明写承诺检查 "execution JSON shape"；
+//   2) OfflineReleaseValidationSuite —— 对外发版的离线验收闸，报 "ok":true 而执行 JSON
+//      构建路径一次都没跑过。
+//
+//  修法是把委托改成必填（编译期堵死），并把真正的检查 ExecutionJsonBuilds 放进分析器自己，
+//  让调用方无处可退。所以本文件既盯运行期行为，也盯 API 形状 ——
+//  形状那条是唯一能拦住「有人手滑把 `= null` 加回去」的检查。
+//
+//  全部离线：不连博途、不起引擎，只读临时目录里的模板 JSON。
+// ─────────────────────────────────────────────────────────────────────────────
+internal static class HmiTemplateLayoutExecutionCheckTests
+{
+    /// <summary>一份布局上完全干净的模板：尺寸合法、条目不越界、名字不重复。</summary>
+    private const string CleanTemplate = @"{
+  ""TemplateName"": ""ExecCheckClean"",
+  ""DesignSystem"": { ""Name"": ""T"", ""Palette"": { ""a"":""#1"",""b"":""#2"",""c"":""#3"",""d"":""#4"",""e"":""#5"",""f"":""#6"" }, ""Layout"": { ""Grid"": 8 } },
+  ""Screen"": { ""Width"": 800, ""Height"": 480 },
+  ""Items"": [
+    { ""Name"": ""Title"", ""Type"": ""Text"", ""Left"": 16, ""Top"": 16, ""Width"": 300, ""Height"": 40 },
+    { ""Name"": ""Start"", ""Type"": ""Button"", ""Left"": 16, ""Top"": 80, ""Width"": 120, ""Height"": 48 }
+  ]
+}";
+
+    public static void Run(Action<bool, string> check)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "tia_hmi_exec_check_" + Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(dir);
+        try
+        {
+            // -- 1. API 形状：委托必须是必填 -------------------------------------
+            // 这是唯一能拦住回归的检查 —— 一旦有人把 `Func<string,bool>? … = null` 加回去，
+            // 空转路径就复活了，而运行期用例（传了委托）一个都不会红。
+            foreach (var name in new[] { "AnalyzeFile", "AnalyzeDirectory" })
+            {
+                var method = typeof(HmiTemplateLayoutAnalyzer).GetMethod(name, BindingFlags.Public | BindingFlags.Static);
+                check(method != null, "能定位 HmiTemplateLayoutAnalyzer." + name + "（定位不到，这条检查本身就是假的）");
+                var parameter = method?.GetParameters().FirstOrDefault(x => x.Name == "executionJsonCheck");
+                check(parameter != null, name + " 仍有 executionJsonCheck 参数");
+                check(parameter != null && !parameter.IsOptional,
+                    name + " 的 executionJsonCheck 不许是可选参数（可选＝「不传就当验过了」的空转路径复活）");
+            }
+
+            var cleanFile = Path.Combine(dir, "unified_clean.json");
+            File.WriteAllText(cleanFile, CleanTemplate, Encoding.UTF8);
+
+            // 传 null 也不许蒙混过关：显式空委托要炸，不能被当成「跳过检查」。
+            check(Throws<ArgumentNullException>(() => HmiTemplateLayoutAnalyzer.AnalyzeFile(cleanFile, null!)),
+                "显式传 null 委托要抛 ArgumentNullException，不许静默降级成不检查");
+
+            // -- 2. 真检查真的会响：布局干净但执行 JSON 建不出来 -------------------
+            // Items 里混进一个非对象条目：布局 QA 用 OfType<JsonObject>() 把它跳过，所以
+            // 布局层面一条错误都没有；而执行 JSON 的条目数会比模板条目数少一个。
+            // 这正是旧同义反复必然漏掉的形态 —— 旧判据 errors.Count == 0 成立 → 报 pass。
+            var mismatchFile = Path.Combine(dir, "unified_mismatch.json");
+            var mismatchRoot = JsonNode.Parse(CleanTemplate)!.AsObject();
+            (mismatchRoot["Items"] as JsonArray)!.Add(JsonValue.Create("not-an-object"));
+            File.WriteAllText(mismatchFile, mismatchRoot.ToJsonString(), Encoding.UTF8);
+
+            check(!HmiTemplateLayoutAnalyzer.ExecutionJsonBuilds(mismatchFile),
+                "执行 JSON 条目数对不上模板条目数时，ExecutionJsonBuilds 必须返回 false");
+
+            var mismatchRow = HmiTemplateLayoutAnalyzer.AnalyzeFile(mismatchFile, HmiTemplateLayoutAnalyzer.ExecutionJsonBuilds);
+            var mismatchErrors = mismatchRow["errors"] as JsonArray ?? new JsonArray();
+            check(!mismatchErrors.Any(x => (x?.ToString() ?? "").StartsWith("json-parse-error")
+                                        || (x?.ToString() ?? "").StartsWith("missing-screen")
+                                        || (x?.ToString() ?? "").StartsWith("item-out-of-screen")
+                                        || (x?.ToString() ?? "").StartsWith("duplicate-item-name")),
+                "该模板在布局层面本来是干净的（旧代码正因如此报 pass）");
+            check(mismatchErrors.Any(x => (x?.ToString() ?? "").StartsWith("execution-json-build-failed")),
+                "执行 JSON 建不出来必须报 execution-json-build-failed");
+            check(string.Equals(mismatchRow["status"]?.ToString(), "fail", StringComparison.OrdinalIgnoreCase),
+                "执行 JSON 检查没过的模板不许报 pass");
+            check(mismatchRow["executionJsonChecked"]?.GetValue<bool>() == false,
+                "executionJsonChecked 要如实报 false");
+
+            // 目录级和顶层结论一起变红，发布闸才拦得住。
+            var dirResult = HmiTemplateLayoutAnalyzer.AnalyzeDirectory(dir, HmiTemplateLayoutAnalyzer.ExecutionJsonBuilds);
+            check(dirResult["ok"]?.GetValue<bool>() == false,
+                "只要有一份模板的执行 JSON 建不出来，目录级 ok 就不许是 true");
+
+            // -- 3. 反向哨兵：真委托返回 true 时行为一个字都没变 -------------------
+            var cleanRow = HmiTemplateLayoutAnalyzer.AnalyzeFile(cleanFile, HmiTemplateLayoutAnalyzer.ExecutionJsonBuilds);
+            check(string.Equals(cleanRow["status"]?.ToString(), "pass", StringComparison.OrdinalIgnoreCase),
+                "[哨兵] 干净模板 + 真检查通过，照旧 pass");
+            check(cleanRow["executionJsonChecked"]?.GetValue<bool>() == true,
+                "[哨兵] 真检查通过时 executionJsonChecked 为 true");
+            check(!(cleanRow["errors"] as JsonArray ?? new JsonArray()).Any(),
+                "[哨兵] 干净模板不许被新检查误伤出错误");
+            check(HmiTemplateLayoutAnalyzer.AnalyzeFile(cleanFile, _ => true)["status"]?.ToString() == "pass",
+                "[哨兵] 自带委托返回 true 的调用方（BuildUnifiedHmiTemplateApplyDesignJson 那条路）行为不变");
+
+            // [哨兵] 委托抛异常仍走 execution-json-build-failed，不许把异常吞成通过。
+            var throwRow = HmiTemplateLayoutAnalyzer.AnalyzeFile(cleanFile, _ => throw new InvalidOperationException("boom"));
+            check(string.Equals(throwRow["status"]?.ToString(), "fail", StringComparison.OrdinalIgnoreCase)
+                  && (throwRow["errors"] as JsonArray ?? new JsonArray())
+                        .Any(x => (x?.ToString() ?? "").Contains("boom")),
+                "[哨兵] 检查自己炸了要报错，不许当成通过");
+        }
+        finally
+        {
+            try { Directory.Delete(dir, true); } catch { /* 临时目录清不掉不影响结论 */ }
+        }
+    }
+
+    private static bool Throws<T>(Action action) where T : Exception
+    {
+        try { action(); return false; }
+        catch (T) { return true; }
+        catch { return false; }
+    }
+}

--- a/tools/tiaportal-mcp/tests/TiaMcpServer.Tests/Program.cs
+++ b/tools/tiaportal-mcp/tests/TiaMcpServer.Tests/Program.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Generic;
+
+namespace TiaMcpServer.Tests
+{
+    /// <summary>
+    /// 最小离线自检套件的入口。不连 TIA Portal，不碰注册表，跑得起 dotnet 就跑得起它。
+    ///
+    /// 它盯的是一类特定的缺陷：**从上线起就没生效过的检查**。
+    /// 这类东西的共同点是「不响的报警器和没装的报警器长得一模一样」——
+    /// 靠人读代码发现不了，只有会失败的用例盯得住。所以每组用例里都放了反向哨兵：
+    /// 正常输入必须照旧通过，否则说明这次是把功能改坏了而不是把检查修好了。
+    ///
+    /// ⚠️ 用 `dotnet run` 驱动，别用 `dotnet test`（见 csproj 里的说明）。
+    /// </summary>
+    internal static class Program
+    {
+        private static int _pass;
+        private static int _fail;
+
+        private static void Check(bool ok, string what)
+        {
+            if (ok)
+            {
+                _pass++;
+            }
+            else
+            {
+                _fail++;
+                Console.WriteLine("  FAIL: " + what);
+            }
+        }
+
+        private static int Main()
+        {
+            Console.WriteLine("== 「执行 JSON 检查」不许是复述已知事实的同义反复 ==");
+            HmiTemplateLayoutExecutionCheckTests.Run(Check);
+
+            Console.WriteLine("== .s7res 的 en-US 扫描（原实现对每个真实文件都抛异常又被吞掉）==");
+            RunS7ResScannerTests();
+
+            Console.WriteLine(_fail == 0
+                ? $"{_pass} passed, {_fail} failed."
+                : $"{_pass} passed, {_fail} failed.  <<< 有失败");
+            return _fail == 0 ? 0 : 1;
+        }
+
+        /// <summary>
+        /// .s7res 是 YAML，不是 XML。原实现拿 XML 解析器去读，对**每一个真实文件**都抛异常，
+        /// 异常又被外面的 catch 吞掉 —— 于是「没有缺失的 en-US 条目」这个结论，
+        /// 是在一次都没真正扫过的情况下得出的。这里用真实形态的行喂它。
+        /// </summary>
+        private static void RunS7ResScannerTests()
+        {
+            // 真实形态：MultiLingualTexts 容器 + 「- id: MLC_xxx」列表项 + 各语言行。
+            var missing = new List<string>
+            {
+                "MultiLingualTexts:",
+                "  - id: MLC_Comment",
+                "    de-DE: 'Start'",
+                "  - id: MLC_Title",
+                "    en-US: 'Stop'",
+            };
+            var ids = TiaMcpServer.ModelContextProtocol.S7ResScanner.GetMissingEnUsIdsFromLines(missing);
+            Check(ids.Contains("MLC_Comment"), "缺 en-US 的条目要被点名（MLC_Comment）");
+            Check(!ids.Contains("MLC_Title"), "有 en-US 的条目不许被误报（MLC_Title）");
+
+            // 反向哨兵：全都有 en-US 时必须一条都不报。
+            // 少了这条，「永远返回空列表」的坏实现也能通过上面那两条里的第二条。
+            var complete = new List<string>
+            {
+                "MultiLingualTexts:",
+                "  - id: MLC_Comment",
+                "    en-US: 'Start'",
+                "  - id: MLC_Title",
+                "    en-US: 'Stop'",
+            };
+            Check(TiaMcpServer.ModelContextProtocol.S7ResScanner.GetMissingEnUsIdsFromLines(complete).Count == 0,
+                "[反向哨兵] 全都有 en-US 时不许报缺失");
+
+            // [哨兵] 空输入不许崩：预检坏掉本身就该看得见，但不该把调用方一起带走。
+            Check(TiaMcpServer.ModelContextProtocol.S7ResScanner.GetMissingEnUsIdsFromLines(new List<string>()).Count == 0,
+                "[哨兵] 空输入返回空列表且不抛");
+        }
+    }
+}

--- a/tools/tiaportal-mcp/tests/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
+++ b/tools/tiaportal-mcp/tests/TiaMcpServer.Tests/TiaMcpServer.Tests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <!--
+    最小离线自检套件。
+
+    为什么是控制台 Exe 而不是 VSTest 工程：这里链接的是引擎的**源文件**，
+    而引擎主体依赖 Siemens.Engineering.dll（需要本机装了 TIA Portal 才编得动），
+    托管不了整个工程。所以只把**零依赖**的那几个文件链进来，用 `dotnet run` 驱动。
+
+    ⚠️ 千万别用 `dotnet test` 跑它：那样只会还原、一个用例都不跑、然后退 0 ——
+    一个和「全部通过」长得一模一样的假绿灯。CI 里写死的是 `dotnet run`。
+  -->
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <!-- HMI 模板布局体检 + 执行 JSON 构建器：两个都零依赖。
+         盯的是「执行 JSON 检查」那条 —— 它曾经在委托缺省时退化成
+         `items.Length > 0 && errors.Count == 0`，判据里含着 errors.Count == 0，
+         永远不可能新增错误，而发版前的离线验收闸走的正是那条空转路径。
+         恒不触发的检查只有会失败的用例盯得住，而且必须同时盯 API 形状：
+         委托一旦被改回可选，空转路径立刻复活，运行期用例一条都不会红。 -->
+    <Compile Include="..\..\src\TiaMcpServer\ModelContextProtocol\HmiTemplateLayoutAnalyzer.cs" Link="HmiTemplateLayoutAnalyzer.cs" />
+    <Compile Include="..\..\src\TiaMcpServer\ModelContextProtocol\HmiTemplateDesignJsonBuilder.cs" Link="HmiTemplateDesignJsonBuilder.cs" />
+    <!-- .s7res 的 en-US 扫描。原实现埋在依赖 MCP SDK 的大文件里，用 XML 解析器读 YAML，
+         对每个真实文件都抛异常又被 catch 吞掉，坏了很久没人发现 —— 抽成零依赖文件
+         就是为了能在这里被测到。 -->
+    <Compile Include="..\..\src\TiaMcpServer\ModelContextProtocol\S7ResScanner.cs" Link="S7ResScanner.cs" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
见提交说明。真机验证 8/8（TIA V21，真实工程副本，全程只读）；离线套件 22/22，含故障注入。